### PR TITLE
リクエスト先のスキームをhttp(s)のみに制限

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,12 @@ fastify.get('/', (request, reply) => {
   const sha1 = crypto.createHash('sha1')
   const fileName = `screenshots/${sha1.update(url).digest('hex')}.png`;
 
+  // Check scheme
+  if (url.match(/^http.+$/) === null) {
+    reply.status(400).send("Bad scheme");
+    return;
+  }
+
   request.log.info(`Save screenshot : ${fileName}`)
 
   let hitCache = true;


### PR DESCRIPTION
パラメータで渡すスクリーンショット対象のURLスキームをhttp(s)のみに制限します